### PR TITLE
Pack jquery.atmosphere.js too

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
-            <version>1.11.1</version>
+            <version>2.0.3</version>
         </dependency>
     </dependencies>
 
@@ -64,6 +64,12 @@
                         <artifactItem>
                             <groupId>org.atmosphere.client</groupId>
                             <artifactId>javascript</artifactId>
+                            <version>${upstreamVersion}</version>
+                            <type>war</type>
+                        </artifactItem>
+                        <artifactItem>
+                            <groupId>org.atmosphere.client</groupId>
+                            <artifactId>jquery</artifactId>
                             <version>${upstreamVersion}</version>
                             <type>war</type>
                         </artifactItem>
@@ -93,6 +99,7 @@
                                 <echo message="moving resources" />
                                 <move todir="${destinationDir}">
                                     <fileset dir="${project.build.directory}/dependency/javascript" includes="atmosphere*" />
+                                    <fileset dir="${project.build.directory}/dependency/jquery" includes="jquery.atmosphere*" />
                                 </move>
                             </target>
                         </configuration>


### PR DESCRIPTION
Is it OK to pack the jquery version of atmosphere.js client in the same webjar ?
Or should we create a new webjar project ? But this will lead to double maintainance.

Also I upgraded the jQuery dependency to 2.0.3 because this is what jquery.atmosphere.js says it depends on.
