### PR TITLE
Updated to v2.2.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>atmosphere-javascript</artifactId>
-    <version>2.2.9-SNAPSHOT</version>
+    <version>2.2.11</version>
     <name>Javascript Atmosphere</name>
     <description>WebJar for Atmosphere Javascript</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstreamVersion>2.2.8</upstreamVersion>
+        <upstreamVersion>2.2.11</upstreamVersion>
         <destinationDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstreamVersion}</destinationDir>       
     </properties>
 
@@ -46,11 +46,6 @@
     </developers>
 
     <dependencies>
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>jquery</artifactId>
-            <version>1.11.1</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Removed the dependency on JQUERY, as it is not required (there is another Atmosphere library called "org.atmosphere.client.jquery" which includes a JQUERY dependency.
